### PR TITLE
Fix casperjs by installing python

### DIFF
--- a/slimerjs/Dockerfile
+++ b/slimerjs/Dockerfile
@@ -3,6 +3,7 @@
 # Usage
 #   docker run cmfatih/slimerjs /usr/bin/slimerjs -v
 #   docker run -v `pwd`:/scripts cmfatih/slimerjs /usr/bin/slimerjs /scripts/test.js
+#   docker run -v `pwd`:/scripts cmfatih/slimerjs /usr/bin/casperjs /scripts/test-casperjs.js
 
 FROM ubuntu:14.04
 
@@ -15,7 +16,7 @@ ENV SLIMERJS_VERSION_F 0.9.6
 RUN \
   apt-get update && \
   apt-get upgrade -y && \
-  apt-get install -y vim git wget xvfb libxrender-dev libasound2 libdbus-glib-1-2 libgtk2.0-0 bzip2 && \
+  apt-get install -y vim git wget xvfb libxrender-dev libasound2 libdbus-glib-1-2 libgtk2.0-0 bzip2 python && \
   mkdir -p /srv/var && \
   wget -O /tmp/slimerjs-$SLIMERJS_VERSION_F-linux-x86_64.tar.bz2 http://download.slimerjs.org/releases/$SLIMERJS_VERSION_F/slimerjs-$SLIMERJS_VERSION_F-linux-x86_64.tar.bz2 && \
   tar -xjf /tmp/slimerjs-$SLIMERJS_VERSION_F-linux-x86_64.tar.bz2 -C /tmp && \

--- a/slimerjs/test-casperjs.js
+++ b/slimerjs/test-casperjs.js
@@ -1,0 +1,11 @@
+var casper = require('casper').create();
+
+casper.start('http://casperjs.org/', function() {
+    this.echo(this.getTitle());
+});
+
+casper.thenOpen('http://phantomjs.org', function() {
+    this.echo(this.getTitle());
+});
+
+casper.run();


### PR DESCRIPTION
/usr/bin/casperjs stopped working in cmfatih/slimerjs:0.9.6:

```
$ docker run cmfatih/slimerjs:0.9.6 /usr/bin/casperjs
/usr/bin/env: python: No such file or directory
```

This change installs python 2.7 into the image, and adds a comment with a command that tests that casperjs still works (from http://docs.casperjs.org/en/latest/quickstart.html).